### PR TITLE
Initial Defect Cluster Concentrations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -99,6 +99,9 @@
       "stop_token": "cpp",
       "thread": "cpp",
       "typeindex": "cpp",
-      "valarray": "cpp"
+      "valarray": "cpp",
+      "execution": "cpp",
+      "queue": "cpp",
+      "stack": "cpp"
     }
 }

--- a/cli/arg_consumer.hpp
+++ b/cli/arg_consumer.hpp
@@ -1,7 +1,9 @@
 #include <yaml-cpp/yaml.h>
 
 #include <boost/program_options.hpp>
+#include <exception>
 #include <string>
+#include <vector>
 
 #include "client_db/client_db.hpp"
 #include "cluster_dynamics/cluster_dynamics.hpp"
@@ -15,7 +17,8 @@ namespace po = boost::program_options;
 
 class ArgConsumer {
  public:
-  ArgConsumer(int argc, char *argv[], const po::options_description &options) {
+  ArgConsumer(int argc, char *argv[], const po::options_description &options)
+      : has_config_file(false) {
     po::store(po::parse_command_line(argc, argv, options), vm);
     po::notify(vm);
 
@@ -106,6 +109,22 @@ class ArgConsumer {
         config["material"]["lattice-param-cm"].as<gp_float>());
   }
 
+  void populate_init_interstitials(ClusterDynamicsConfig &cd_config) {
+    cd_config.init_interstitials =
+        std::vector<gp_float>(cd_config.max_cluster_size, 0.);
+
+    populate_vector_from_config(cd_config.init_interstitials,
+                                config["init-interstitials"]);
+  }
+
+  void populate_init_vacancies(ClusterDynamicsConfig &cd_config) {
+    cd_config.init_vacancies =
+        std::vector<gp_float>(cd_config.max_cluster_size, 0.);
+
+    populate_vector_from_config(cd_config.init_vacancies,
+                                config["init-vacancies"]);
+  }
+
   SensitivityVariable get_sa_var() {
     std::string arg_name =
         get_value<std::string>("sensitivity-var", "sensitivity-analysis");
@@ -121,4 +140,57 @@ class ArgConsumer {
   po::variables_map vm;
   YAML::Node config;
   bool has_config_file;
+
+  void populate_vector_from_config(std::vector<gp_float> &vec,
+                                   const YAML::Node &vec_config) {
+    if (has_config_file && vec_config.IsMap()) {
+      YAML::Node array_node = vec_config["array"];
+      YAML::Node ranges_node = vec_config["ranges"];
+
+      // array mapping
+      if (array_node.IsSequence()) {
+        for (size_t i = 0; i < array_node.size() && i < vec.size() - 1; ++i) {
+          // index 0 from the config represents size 1 cluster concentration
+          gp_float value = array_node[i].as<gp_float>();
+
+          if (value < 0.) {
+            throw std::runtime_error(
+                "defect array values must be greater than or equal to 0.0");
+          }
+
+          vec[i + 1] = value;
+        }
+      }
+
+      // range mapping
+      if (ranges_node.IsSequence()) {
+        for (size_t i = 0; i < ranges_node.size(); ++i) {
+          if (ranges_node[i].size() == 3) {
+            size_t start_index = ranges_node[i][0].as<size_t>();
+            size_t end_index = ranges_node[i][1].as<size_t>();
+            gp_float value = ranges_node[i][2].as<gp_float>();
+
+            if (start_index > end_index) start_index = end_index;
+
+            if (end_index > vec.size() - 1) end_index = vec.size() - 1;
+
+            if (value < 0.) {
+              throw std::runtime_error(
+                  "defect array values must be greater than or equal to 0.0");
+            }
+
+            for (size_t i = start_index; i <= end_index; ++i) {
+              vec[i] = value;
+            }
+          } else {
+            throw std::runtime_error(
+                "ranges must be have 3 elements: [start, end, value]");
+          }
+        }
+      }
+    } else {
+      throw std::runtime_error(
+          "defect array value config is improperly formatted");
+    }
+  }
 };

--- a/cli/cd_cli.cpp
+++ b/cli/cd_cli.cpp
@@ -739,13 +739,13 @@ int main(int argc, char* argv[]) {
     if (arg_consumer.has_arg("init-interstitials", "")) {
       arg_consumer.populate_init_interstitials(config);
     } else {
-      config.init_interstitials = std::vector<gp_float>(0.);
+      config.init_interstitials = std::vector<gp_float>(config.max_cluster_size, 0.);
     }
 
     if (arg_consumer.has_arg("init-vacancies", "")) {
       arg_consumer.populate_init_vacancies(config);
     } else {
-      config.init_vacancies = std::vector<gp_float>(0.);
+      config.init_vacancies = std::vector<gp_float>(config.max_cluster_size, 0.);
     }
 
     ClientDb db(DEV_DEFAULT_CLIENT_DB_PATH, false);

--- a/cli/cd_cli.cpp
+++ b/cli/cd_cli.cpp
@@ -114,6 +114,16 @@ void print_start_message() {
   print_material();
 
   std::cout << std::endl;
+
+  std::cout << "\nInitial Defect Clustering";
+  std::cout << "\nCluster Size\t\t-\t\tInterstitials\t\t-\t\tVacancies\n\n";
+  for (size_t n = 1; n < config.max_cluster_size; ++n) {
+    if (config.init_interstitials[n] > 0. || config.init_vacancies[n] > 0.) {
+      std::cout << (long long unsigned int)n << "\t\t\t\t\t"
+                << config.init_interstitials[n] << "\t\t\t"
+                << config.init_vacancies[n] << std::endl;
+    }
+  }
 }
 
 void print_state(const ClusterDynamicsState& state) {
@@ -379,8 +389,57 @@ void emit_config_yaml(const std::string& filename) {
       << "initial-dislocation-density-cm" << YAML::Value << "10.0e+12"
       << YAML::Key << "grain-size-cm" << YAML::Value << "4.0e-3" << YAML::Key
       << "lattice-param-cm" << YAML::Value << "3.6e-8" << YAML::EndMap
-      << YAML::EndMap << YAML::Newline << YAML::Newline
-      << YAML::Comment("NOTE: uncomment to turn on sensitivity analysis")
+      << YAML::EndMap << YAML::Newline << YAML::Newline << YAML::Newline
+      << YAML::Comment(
+             "#################################################################"
+             "####")
+      << YAML::Newline
+      << YAML::Comment(
+             "INITIAL DEFECT CLUSTER CONCENTRATIONS "
+             "###############################")
+      << YAML::Newline
+      << YAML::Comment(
+             "you can define a subset of the array of concentrations with "
+             "\"array\"")
+      << YAML::Newline
+      << YAML::Comment(
+             "and define ranges throughout the array with \"ranges\" ")
+      << YAML::Newline
+      << YAML::Comment(
+             "#################################################################"
+             "####")
+      << YAML::Newline << YAML::BeginMap << YAML::Key << "init-interstitials"
+      << YAML::Value << YAML::BeginMap << YAML::Key << "array" << YAML::Value
+      << YAML::Flow
+      << std::vector<std::string>{"1.0e-13", "6.0e-10", "4.0e-2", "2.0e-1"}
+      << YAML::Comment("cluster concentrations for cluster sizes 1-4")
+      << YAML::Key << "ranges" << YAML::Value << YAML::BeginSeq << YAML::Flow
+      << std::vector<std::string>{"50", "55", "9.9e+30"}
+      << YAML::Comment("cluster concentrations for cluster sizes 50-55")
+      << YAML::Flow << std::vector<std::string>{"90", "102", "5.5e+29"}
+      << YAML::Comment("cluster concentrations for cluster sizes 90-102")
+      << YAML::Flow << std::vector<std::string>{"995", "1000", "2.2e+22"}
+      << YAML::Comment("cluster concentrations for cluster sizes 995-1000")
+      << YAML::EndSeq << YAML::EndMap << YAML::EndMap << YAML::Newline
+      << YAML::Newline << YAML::BeginMap << YAML::Key << "init-vacancies"
+      << YAML::Value << YAML::BeginMap << YAML::Key << "array" << YAML::Value
+      << YAML::Flow
+      << std::vector<std::string>{"1.0e-5", "2.3e-1", "4.2e-20", "1.3e-13"}
+      << YAML::Comment("cluster concentrations for cluster sizes 1-4")
+      << YAML::Key << "ranges" << YAML::Value << YAML::BeginSeq << YAML::Flow
+      << std::vector<std::string>{"50", "55", "6.2e+29"}
+      << YAML::Comment("cluster concentrations for cluster sizes 50-55")
+      << YAML::Flow << std::vector<std::string>{"90", "102", "1.5e+13"}
+      << YAML::Comment("cluster concentrations for cluster sizes 90-102")
+      << YAML::Flow << std::vector<std::string>{"995", "1000", "4.3e+12"}
+      << YAML::Comment("cluster concentrations for cluster sizes 995-1000")
+      << YAML::EndSeq << YAML::EndMap << YAML::EndMap << YAML::Newline
+      << YAML::Newline
+      << YAML::Comment(
+             "#################################################################"
+             "####")
+      << YAML::Newline << YAML::Newline
+      << YAML::Comment("UNCOMMENT LINES BELOW TO TURN ON SENSITIVITY ANALYSIS")
       << YAML::Newline << YAML::Comment(sa_comment.c_str()) << YAML::Newline;
 
   std::ofstream file;
@@ -675,6 +734,18 @@ int main(int argc, char* argv[]) {
       arg_consumer.populate_material(config.material);
     } else {
       materials::SA304(config.material);
+    }
+
+    if (arg_consumer.has_arg("init-interstitials", "")) {
+      arg_consumer.populate_init_interstitials(config);
+    } else {
+      config.init_interstitials = std::vector<gp_float>(0.);
+    }
+
+    if (arg_consumer.has_arg("init-vacancies", "")) {
+      arg_consumer.populate_init_vacancies(config);
+    } else {
+      config.init_vacancies = std::vector<gp_float>(0.);
     }
 
     ClientDb db(DEV_DEFAULT_CLIENT_DB_PATH, false);

--- a/cli/cd_cli.cpp
+++ b/cli/cd_cli.cpp
@@ -739,13 +739,15 @@ int main(int argc, char* argv[]) {
     if (arg_consumer.has_arg("init-interstitials", "")) {
       arg_consumer.populate_init_interstitials(config);
     } else {
-      config.init_interstitials = std::vector<gp_float>(config.max_cluster_size, 0.);
+      config.init_interstitials =
+          std::vector<gp_float>(config.max_cluster_size, 0.);
     }
 
     if (arg_consumer.has_arg("init-vacancies", "")) {
       arg_consumer.populate_init_vacancies(config);
     } else {
-      config.init_vacancies = std::vector<gp_float>(config.max_cluster_size, 0.);
+      config.init_vacancies =
+          std::vector<gp_float>(config.max_cluster_size, 0.);
     }
 
     ClientDb db(DEV_DEFAULT_CLIENT_DB_PATH, false);

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,75 @@
+simulation:
+  time: 1.0e+8
+  time-delta: 1.0e+6
+  sample-interval: 1.0e+6
+  data-validation: on
+  max-cluster-size: 1001
+  relative-tolerance: 1.0e-6
+  absolute-tolerance: 1.0e+1
+  max-num-integration-steps: 5000
+  min-integration-step: 1.0e-30
+  max-integration-step: 1.0e+20
+
+
+reactor:
+  flux-dpa-s: 2.9e-7
+  temperature-kelvin: 603.15
+  recombination-rate: 0.3
+  bi-interstitial-rate: 0.5
+  tri-interstitial-rate: 0.2
+  quad-interstitial-rate: 0.06
+  bi-vacancy-rate: 0.06
+  tri-vacancy-rate: 0.03
+  quad-vacancy-rate: 0.02
+  dislocation-density-evolution: 300.0
+
+
+material:
+  interstitial-migration-ev: 0.45
+  vacancy-migration-ev: 1.35
+  initial-interstitial-diffusion: 1.0e-3
+  initial-vacancy-diffusion: 0.6
+  interstitial-formation-ev: 4.1
+  vacancy-formation-ev: 4.1
+  interstitial-binding-ev: 0.6
+  vacancy-binding-ev: 0.5
+  recombination-radius-cm: 0.7e-7
+  interstitial-loop-bias: 63.0
+  interstitial-dislocation-bias: 0.8
+  interstitial-dislocation-bias-param: 1.1
+  vacancy-loop-bias: 33.0
+  vacancy-dislocation-bias: 0.65
+  vacancy-dislocation-bias-param: 1.0
+  initial-dislocation-density-cm: 10.0e+12
+  grain-size-cm: 4.0e-3
+  lattice-param-cm: 3.6e-8
+
+
+# #####################################################################
+# INITIAL DEFECT CLUSTER CONCENTRATIONS ###############################
+# you can define a subset of the array of concentrations with "array"
+# and define ranges throughout the array with "ranges" 
+# #####################################################################
+
+init-interstitials:
+  array: [1.0e-13, 6.0e-10, 4.0e-2, 2.0e-1]  # cluster concentrations for cluster sizes 1-4
+  ranges:
+    - [50, 55, 9.9e+30]  # cluster concentrations for cluster sizes 50-55
+    - [90, 102, 5.5e+29]  # cluster concentrations for cluster sizes 90-102
+    - [995, 1000, 2.2e+22]  # cluster concentrations for cluster sizes 995-1000
+
+
+init-vacancies:
+  array: [1.0e-5, 2.3e-1, 4.2e-20, 1.3e-13]  # cluster concentrations for cluster sizes 1-4
+  ranges:
+    - [50, 55, 6.2e+29]  # cluster concentrations for cluster sizes 50-55
+    - [90, 102, 1.5e+13]  # cluster concentrations for cluster sizes 90-102
+    - [995, 1000, 4.3e+12]  # cluster concentrations for cluster sizes 995-1000
+
+# #####################################################################
+
+# UNCOMMENT LINES BELOW TO TURN ON SENSITIVITY ANALYSIS
+# sensitivity-analysis:
+#   num-sims: 10
+#   sensitivity-var: flux-dpa-s
+#   sensitivity-var-delta: 1.0e-7

--- a/include/cluster_dynamics/cluster_dynamics_config.hpp
+++ b/include/cluster_dynamics/cluster_dynamics_config.hpp
@@ -2,6 +2,7 @@
 #define CLUSTER_DYNAMICS_CONFIG_HPP
 
 #include <cstring>
+#include <vector>
 
 #include "model/material.hpp"
 #include "model/nuclear_reactor.hpp"
@@ -26,6 +27,9 @@ struct ClusterDynamicsConfig {
 
   NuclearReactor reactor;
   Material material;
+
+  std::vector<gp_float> init_interstitials;
+  std::vector<gp_float> init_vacancies;
 };
 
 #endif  // CLUSTER_DYNAMICS_CONFIG_HPP

--- a/src/cluster_dynamics/cpu/cluster_dynamics_impl.cpp
+++ b/src/cluster_dynamics/cpu/cluster_dynamics_impl.cpp
@@ -1217,11 +1217,13 @@ ClusterDynamicsImpl::ClusterDynamicsImpl(ClusterDynamicsConfig& config)
   dislocation_density = vacancies + max_cluster_size + 2;
 
   /* Initialize State Values */
-  N_VConst(0., state);
+  for (size_t i = 0; i < max_cluster_size; ++i) {
+    interstitials[i] = config.init_interstitials[i];
+    vacancies[i] = config.init_vacancies[i];
+  }
+
   *dislocation_density = material.dislocation_density_0;
-  interstitials[0] = 0.0;
   interstitials[max_cluster_size + 1] = 0.0;
-  vacancies[0] = 0.0;
   vacancies[max_cluster_size + 1] = 0.0;
 
   /* Call CVodeCreate to create the solver memory and specify the

--- a/src/cluster_dynamics/cuda/cluster_dynamics_cuda_impl.cpp
+++ b/src/cluster_dynamics/cuda/cluster_dynamics_cuda_impl.cpp
@@ -817,7 +817,13 @@ ClusterDynamicsImpl::ClusterDynamicsImpl(ClusterDynamicsConfig &config)
   state = N_VNew_Serial(state_size, sun_context);
 
   /* Initialize State Values */
-  N_VConst(0.1, state);
+  gp_float *i_state = N_VGetArrayPointer(state);
+  gp_float *v_state = i_state + max_cluster_size + 2;
+  for (size_t i = 0; i < max_cluster_size; ++i) {
+    i_state[i] = config.init_interstitials[i];
+    v_state[i] = config.init_vacancies[i];
+  }
+
   N_VGetArrayPointer(state)[state_size - 2] = material.dislocation_density_0;
 
   /* Call CVodeCreate to create the solver memory and specify the


### PR DESCRIPTION
- Concentrations definable via a .yaml file with `init-interstitials` and `init-vacancies`
  - `array` defines the entire array starting at index 1
  - `ranges` defines ranges within the array
- Expands `--generate-config-file` to show an example syntax of defining initial concentrations
